### PR TITLE
Refactor poc methods and games

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1,14 +1,14 @@
-from games.digit_party.run import human_game as digit_party_human_game
-from games.digit_party.run import many_trained_games as digit_party_many_trained_games
-from games.digit_party.run import trained_game as digit_party_trained_game
+# from games.digit_party.run import human_game as digit_party_human_game
+# from games.digit_party.run import many_trained_games as digit_party_many_trained_games
+# from games.digit_party.run import trained_game as digit_party_trained_game
 
 # digit_party_human_game()
-digit_party_trained_game(game_size=3)
-digit_party_many_trained_games(game_size=3)
+# digit_party_trained_game(game_size=3)
+# digit_party_many_trained_games(game_size=3)
 
-# from games.random_walk.random_walk import q_trained_game as random_walk_trained_game
+from games.random_walk.random_walk import q_trained_game as random_walk_trained_game
 
-# random_walk_trained_game()
+random_walk_trained_game()
 
 # from games.tictactoe.tictactoe import monte_carlo_many_games as ttt_mc_many_games
 # from games.tictactoe.tictactoe import monte_carlo_trained_game as ttt_mc_trained_game

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1,10 +1,10 @@
-# from games.digit_party.run import human_game as digit_party_human_game
-# from games.digit_party.run import many_trained_games as digit_party_many_trained_games
-# from games.digit_party.run import trained_game as digit_party_trained_game
+from games.digit_party.run import human_game as digit_party_human_game
+from games.digit_party.run import many_trained_games as digit_party_many_trained_games
+from games.digit_party.run import trained_game as digit_party_trained_game
 
 # digit_party_human_game()
-# digit_party_trained_game(game_size=3)
-# digit_party_many_trained_games(game_size=3)
+digit_party_trained_game(game_size=3)
+digit_party_many_trained_games(game_size=3)
 
 # from games.random_walk.random_walk import q_trained_game as random_walk_trained_game
 
@@ -16,6 +16,6 @@
 # ttt_mc_trained_game(training_episodes=1000000)
 # ttt_mc_many_games()
 
-from games.ultimate_ttt.run import alpha_zero_trained_game
+# from games.ultimate_ttt.run import alpha_zero_trained_game
 
-alpha_zero_trained_game()
+# alpha_zero_trained_game()

--- a/src/games/digit_party/game.py
+++ b/src/games/digit_party/game.py
@@ -93,7 +93,7 @@ class DigitParty(Game[DigitPartyState, DigitPartyIR]):
     def _check_range(n: int, r: int, c: int) -> None:
         if r < 0 or r >= n or c < 0 or c >= n:
             raise ValueError(f"Row {r} or column {c} outside of board of size {n}")
-    
+
     def from_action(self, a: Action) -> DigitPartyPlacement:
         r = int(a / self.n)
         c = a % self.n
@@ -290,9 +290,9 @@ class DigitParty(Game[DigitPartyState, DigitPartyIR]):
             board=tuple(tuple(row) for row in state.board),
             next=state.next,
             score=state.score,
-            digits=tuple(state.digits)
+            digits=tuple(state.digits),
         )
-    
+
     @staticmethod
     def from_immutable(ir: DigitPartyIR) -> DigitPartyState:
         return DigitPartyState(
@@ -300,7 +300,7 @@ class DigitParty(Game[DigitPartyState, DigitPartyIR]):
             player=P1,
             next=ir.next,
             score=ir.score,
-            digits=list(ir.digits)
+            digits=list(ir.digits),
         )
 
     def state(self) -> DigitPartyState:

--- a/src/games/digit_party/run.py
+++ b/src/games/digit_party/run.py
@@ -3,7 +3,7 @@ from typing import List
 from matplotlib import pyplot as plt
 from typing_extensions import override
 
-from games.digit_party.game import DigitParty, DigitPartyIR, DigitPartyPlacement, Empty
+from games.digit_party.game import DigitParty
 from learners.q import SimpleQLearner, SimpleQParameters
 from learners.trainer import Trainer
 
@@ -156,7 +156,7 @@ def many_trained_games(game_size: int, games=10000) -> None:
     percentages = []
     for e in range(1, games + 1):
         while not t.is_finished():
-            action= q.choose_action(DigitParty.to_immutable(t.state()), exploit=True)
+            action = q.choose_action(DigitParty.to_immutable(t.state()), exploit=True)
             t.place(action)
 
         score += t.score

--- a/src/games/game.py
+++ b/src/games/game.py
@@ -53,9 +53,17 @@ class Game(ABC, Generic[State, Immutable]):
 
     @staticmethod
     @abstractmethod
-    def immutable_of(state: State) -> Immutable:
+    def to_immutable(state: State) -> Immutable:
         """
         Returns an immutable (hashable) representation of the given game state.
+        """
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def from_immutable(ir: Immutable) -> State:
+        """
+        Returns the state of the game given the immutable representation.
         """
         pass
 

--- a/src/games/game.py
+++ b/src/games/game.py
@@ -21,7 +21,7 @@ class BasicState:
 
 State = TypeVar("State", bound=BasicState)
 Action = int
-ImmutableRepresentation = TypeVar("ImmutableRepresentation")  # TODO: enforce hashable
+Immutable = TypeVar("Immutable")  # TODO: enforce hashable/immutable
 
 ActionStatus = Literal[1, 0]
 VALID: ActionStatus = 1
@@ -36,7 +36,7 @@ def switch_player(p: Player) -> Player:
     return P1 if p == P2 else P2
 
 
-class Game(ABC, Generic[State, ImmutableRepresentation]):
+class Game(ABC, Generic[State, Immutable]):
     @abstractmethod
     def reset(self) -> None:
         """
@@ -53,7 +53,7 @@ class Game(ABC, Generic[State, ImmutableRepresentation]):
 
     @staticmethod
     @abstractmethod
-    def immutable_of(state: State) -> ImmutableRepresentation:
+    def immutable_of(state: State) -> Immutable:
         """
         Returns an immutable (hashable) representation of the given game state.
         """
@@ -76,6 +76,7 @@ class Game(ABC, Generic[State, ImmutableRepresentation]):
     def actions(state: State) -> List[ActionStatus]:
         """
         Get all the actions available at the given state. 1 represents a valid action and 0 represents invalid.
+        For example, if this returns [1, 0, 0], then 0 is a valid action, and 1 and 2 are invalid actions.
         """
         pass
 

--- a/src/games/random_walk/random_walk.py
+++ b/src/games/random_walk/random_walk.py
@@ -1,21 +1,42 @@
-import pickle
-from enum import Enum, auto
-from typing import List
+from typing import List, NamedTuple
 
+import numpy as np
+from numpy.typing import NDArray
 from typing_extensions import override
 
-from learners.monte_carlo import MonteCarloLearner
-from learners.q import SimpleQLearner
+from games.game import P1, Action, ActionStatus, BasicState, Board, Game, Player
+from learners.q import SimpleQLearner, SimpleQParameters
 from learners.trainer import Trainer
 
 
-class Action(Enum):
-    L = auto()
-    R = auto()
-    N = auto()
+class RandomWalkState(BasicState):
+    def __init__(
+        self,
+        board: Board,
+        player: Player,
+        i: int,
+        left: int,
+        right: int,
+        goal: int,
+        score: int,
+    ) -> None:
+        super().__init__(board, player)  # unused
+        self.i = i
+        self.left = left
+        self.right = right
+        self.goal = goal
+        self.score = score
 
 
-class RandomWalk:
+class RandomWalkIR(NamedTuple):
+    i: int
+    left: int
+    right: int
+    goal: int
+    score: int
+
+
+class RandomWalk(Game[RandomWalkState, RandomWalkIR]):
     """
     A random walk game where the goal is to score some number of points.
     At the right bound, 1 point is scored, at the left bound, 1 point is lost.
@@ -33,21 +54,92 @@ class RandomWalk:
         self.score = 0
         self.i = 0
 
-    @staticmethod
-    def apply(state: int, action: Action) -> int:
-        delta = 0
-        if action == Action.L:
-            delta = -1
-        elif action == Action.R:
-            delta = 1
+    def state(self) -> RandomWalkState:
+        return RandomWalkState(
+            board=np.asarray([]),
+            player=P1,
+            i=self.i,
+            left=self.l_bound,
+            right=self.r_bound,
+            goal=self.goal,
+            score=self.score,
+        )
 
-        return state + delta
+    @staticmethod
+    def orient_state(state: RandomWalkState) -> RandomWalkState:
+        return state  # no need to orient
+
+    @staticmethod
+    def symmetries_of(a: NDArray) -> List[NDArray]:
+        return [a]
+
+    @staticmethod
+    def to_immutable(state: RandomWalkState) -> RandomWalkIR:
+        return RandomWalkIR(
+            i=state.i,
+            left=state.left,
+            right=state.right,
+            goal=state.goal,
+            score=state.score,
+        )
+
+    @staticmethod
+    def from_immutable(ir: RandomWalkIR) -> RandomWalkState:
+        return RandomWalkState(
+            board=np.asarray([]),
+            player=P1,
+            i=ir.i,
+            left=ir.left,
+            right=ir.right,
+            goal=ir.goal,
+            score=ir.score,
+        )
+
+    @staticmethod
+    def action_to_char(a: Action) -> str:
+        if a == 0:
+            return "L"
+        elif a == 1:
+            return "N"
+        elif a == 2:
+            return "R"
+        else:
+            raise ValueError(f"Invalid action {a}")
+
+    @staticmethod
+    def from_action(a: Action) -> int:
+        if a == 0:
+            return -1
+        elif a == 1:
+            return 0
+        elif a == 2:
+            return 1
+        else:
+            raise ValueError(f"Invalid action {a}")
+
+    def num_actions(self) -> int:
+        return 3  # move left, move right, stand
+
+    @staticmethod
+    def actions(state: RandomWalkState) -> List[ActionStatus]:
+        return [1, 1, 1]  # all actions are always valid
+
+    @staticmethod
+    def apply(state: RandomWalkState, action: Action) -> RandomWalkState:
+        delta = RandomWalk.from_action(action)
+        return RandomWalkState(
+            board=state.board,
+            player=state.player,
+            i=state.i + delta,
+            left=state.left,
+            right=state.right,
+            goal=state.goal,
+            score=state.score,
+        )
 
     def step(self, action: Action) -> None:
-        if action == Action.L:
-            self.i -= 1
-        elif action == Action.R:
-            self.i += 1
+        delta = RandomWalk.from_action(action)
+        self.i += delta
 
         if self.at_left():
             self.score -= 1
@@ -60,29 +152,34 @@ class RandomWalk:
     def at_right(self) -> bool:
         return self.i == self.r_bound
 
-    def get_state(self) -> int:
-        return self.i
+    @staticmethod
+    def check_finished(state: RandomWalkState) -> bool:
+        return state.score >= state.goal
 
     def finished(self) -> bool:
-        return self.score >= self.goal
+        return RandomWalk.check_finished(self.state())
+
+    @staticmethod
+    def calculate_reward(state: RandomWalkState) -> float:
+        return float(state.score)
 
     def show(self) -> str:
         return f"random walk at {self.i} with score {self.score}"
 
 
-class RandomWalkQLearner(SimpleQLearner[int, Action]):
-    def default_action_q_values(self) -> dict[Action, float]:
-        actions = {}
-        for a in Action:
-            actions[a] = 0.0
-        return actions
+# class RandomWalkQLearner(SimpleQLearner[int, Action]):
+#     def default_action_q_values(self) -> dict[Action, float]:
+#         actions = {}
+#         for a in Action:
+#             actions[a] = 0.0
+#         return actions
 
-    def get_actions_from_state(self, state: int) -> List[Action]:
-        return [Action.L, Action.R, Action.N]
+#     def get_actions_from_state(self, state: int) -> List[Action]:
+#         return [Action.L, Action.R, Action.N]
 
 
 class RandomWalkQTrainer(RandomWalk, Trainer):
-    def __init__(self, player: RandomWalkQLearner, left=-6, right=6, goal=10) -> None:
+    def __init__(self, player: SimpleQLearner, left=-6, right=6, goal=10) -> None:
         super().__init__(left, right, goal)
         self.player = player
 
@@ -93,102 +190,107 @@ class RandomWalkQTrainer(RandomWalk, Trainer):
 
     def train_once(self) -> None:
         while not self.finished():
-            state = self.get_state()
+            ir = RandomWalk.to_immutable(self.state())
 
-            action = self.player.choose_action(state)
+            action = self.player.choose_action(ir)
             self.step(action)
 
-            new_state = self.get_state()
+            new_ir = RandomWalk.to_immutable(self.state())
 
             # reward minimizing distance to right bound
-            new_r_dist = abs(self.r_bound - new_state)
-            old_r_dist = abs(self.r_bound - state)
+            new_r_dist = abs(self.r_bound - new_ir.i)
+            old_r_dist = abs(self.r_bound - ir.i)
             reward = old_r_dist - new_r_dist
 
             if self.at_right():
                 reward += 1
 
-            self.player.update_q_value(state, action, reward, new_state)
+            self.player.update_q_value(ir, action, reward, new_ir)
 
         self.reset()
 
 
 def q_trained_game() -> None:
     pkl_file = "src/games/random_walk/q.pkl"
-    q = RandomWalkQLearner(epsilon=0.5, q_pickle=pkl_file)
-    g = RandomWalkQTrainer(player=q)
-    g.train()
+    q = SimpleQLearner(
+        game=RandomWalk(),
+        q_pickle=pkl_file,
+        params=SimpleQParameters(alpha=0.1, gamma=0.9, epsilon=0.5),
+    )
+    t = RandomWalkQTrainer(player=q)
+    t.train(episodes=0)
 
-    while not g.finished():
-        print(f"\n{g.show()}\n")
+    while not t.finished():
+        print(f"\n{t.show()}\n")
 
-        action = q.choose_action(g.get_state(), exploit=True)
-        g.step(action)
+        action = q.choose_action(RandomWalk.to_immutable(t.state()), exploit=True)
+        t.step(action)
 
-        print(f"computer takes {action} action")
+        print(f"computer takes {RandomWalk.action_to_char(action)} action")
 
-    print(f"\nrandom walk ended! {g.show()}\n")
+    print(f"\nrandom walk ended! {t.show()}\n")
 
-    with open(pkl_file, "rb") as file:
-        q_table = pickle.load(file)
-        for i in range(g.l_bound, g.r_bound + 1):
-            print("state: ", i)
-            for a, r in q_table[i].items():
-                print(a, " has reward ", r)
-            print()
-
-
-class RandomWalkMonteCarloLearner(MonteCarloLearner[int, Action]):
-    def get_actions_from_state(self, state: int) -> List[Action]:
-        return [Action.L, Action.R, Action.N]
-
-    def apply(self, state: int, action: Action) -> int:
-        return RandomWalk.apply(state, action)
+    # with open(pkl_file, "rb") as file:
+    #     q_table = pickle.load(file)
+    #     for i in range(t.l_bound, t.r_bound + 1):
+    #         print("state: ", i)
+    #         for a, r in q_table[i].items():
+    #             print(type(r))
+    #             print(RandomWalk.action_to_char(a), " has reward ", r)
+    #         print()
 
 
-class RandomWalkMonteCarloTrainer(RandomWalk):
-    # changing the defaults in the init will simplify monte carlo a lot more as compared to q learning
-    def __init__(self, player: MonteCarloLearner, left=-3, right=3, goal=1) -> None:
-        super().__init__(left, right, goal)
-        self.player = player
+# class RandomWalkMonteCarloLearner(MonteCarloLearner[int, Action]):
+#     def get_actions_from_state(self, state: int) -> List[Action]:
+#         return [Action.L, Action.R, Action.N]
 
-    def train(self, episodes=1000) -> None:
-        for e in range(1, episodes + 1):
-            self.train_once()
-
-            if e % 100 == 0:
-                print(f"Episode {e}/{episodes}")
-
-        self.player.save_policy()
-
-    def train_once(self) -> None:
-        while not self.finished():
-            a = self.player.choose_action(self.get_state())
-            self.step(a)
-            self.player.add_state(self.get_state())
-
-        self.player.propagate_reward(1)
-        self.reset()
-        self.player.reset_states()
+#     def apply(self, state: int, action: Action) -> int:
+#         return RandomWalk.apply(state, action)
 
 
-def monte_carlo_trained_game(training_episodes=10000):
-    policy_pkl = "src/games/random_walk/monte_carlo_player.pkl"
-    p = RandomWalkMonteCarloLearner(policy_file=policy_pkl)
-    g = RandomWalkMonteCarloTrainer(p)
-    g.train(episodes=training_episodes)
+# class RandomWalkMonteCarloTrainer(RandomWalk):
+#     # changing the defaults in the init will simplify monte carlo a lot more as compared to q learning
+#     def __init__(self, player: MonteCarloLearner, left=-3, right=3, goal=1) -> None:
+#         super().__init__(left, right, goal)
+#         self.player = player
 
-    while not g.finished():
-        print(f"{g.show()}\n")
+#     def train(self, episodes=1000) -> None:
+#         for e in range(1, episodes + 1):
+#             self.train_once()
 
-        action = p.choose_action(g.get_state())
-        g.step(action)
+#             if e % 100 == 0:
+#                 print(f"Episode {e}/{episodes}")
 
-        print(f"computer takes {action} action")
+#         self.player.save_policy()
 
-    print(f"\nrandom walk ended! {g.show()}\n")
+#     def train_once(self) -> None:
+#         while not self.finished():
+#             a = self.player.choose_action(self.get_state())
+#             self.step(a)
+#             self.player.add_state(self.get_state())
 
-    with open(policy_pkl, "rb") as file:
-        state_values = pickle.load(file)
-        for i in range(g.l_bound * 3, g.r_bound * 3 + 1):
-            print(f"state {i} has value {state_values[i]}")
+#         self.player.propagate_reward(1)
+#         self.reset()
+#         self.player.reset_states()
+
+
+# def monte_carlo_trained_game(training_episodes=10000):
+#     policy_pkl = "src/games/random_walk/monte_carlo_player.pkl"
+#     p = RandomWalkMonteCarloLearner(policy_file=policy_pkl)
+#     g = RandomWalkMonteCarloTrainer(p)
+#     g.train(episodes=training_episodes)
+
+#     while not g.finished():
+#         print(f"{g.show()}\n")
+
+#         action = p.choose_action(g.get_state())
+#         g.step(action)
+
+#         print(f"computer takes {action} action")
+
+#     print(f"\nrandom walk ended! {g.show()}\n")
+
+#     with open(policy_pkl, "rb") as file:
+#         state_values = pickle.load(file)
+#         for i in range(g.l_bound * 3, g.r_bound * 3 + 1):
+#             print(f"state {i} has value {state_values[i]}")

--- a/src/games/tictactoe/tictactoe.py
+++ b/src/games/tictactoe/tictactoe.py
@@ -17,7 +17,6 @@ from games.game import (
     switch_player,
 )
 from learners.monte_carlo import MonteCarloLearner
-from learners.q import SimpleQLearner
 from learners.trainer import Trainer
 
 Tile = Literal[1, 0, -1]
@@ -211,9 +210,7 @@ class TicTacToe(Game[TicTacToeState, TicTacToeIR]):
 
     @staticmethod
     def from_immutable(ir: TicTacToeIR) -> TicTacToeState:
-        return TicTacToeState(
-            board=np.asarray(ir.board), player=ir.player
-        )
+        return TicTacToeState(board=np.asarray(ir.board), player=ir.player)
 
     @staticmethod
     def orient_state(state: TicTacToeState) -> TicTacToeState:

--- a/src/games/tictactoe/tictactoe.py
+++ b/src/games/tictactoe/tictactoe.py
@@ -116,7 +116,7 @@ class TicTacToe(Game[TicTacToeState, TicTacToeIR]):
     @staticmethod
     def applyIR(ir: TicTacToeIR, a: Action) -> TicTacToeIR:
         s = TicTacToeState(board=np.asarray(ir.board), player=ir.player)
-        return TicTacToe.immutable_of(TicTacToe.apply(s, a))
+        return TicTacToe.to_immutable(TicTacToe.apply(s, a))
 
     @staticmethod
     def _is_win(p: Player, board: TTTBoard) -> bool:
@@ -204,9 +204,15 @@ class TicTacToe(Game[TicTacToeState, TicTacToeIR]):
         return syms
 
     @staticmethod
-    def immutable_of(state: TicTacToeState) -> TicTacToeIR:
+    def to_immutable(state: TicTacToeState) -> TicTacToeIR:
         return TicTacToeIR(
             board=TicTacToe.get_board_rep(state.board), player=state.player
+        )
+
+    @staticmethod
+    def from_immutable(ir: TicTacToeIR) -> TicTacToeState:
+        return TicTacToeState(
+            board=np.asarray(ir.board), player=ir.player
         )
 
     @staticmethod
@@ -274,16 +280,16 @@ class TicTacToeMonteCarloTrainer(TicTacToe, Trainer):
 
     def train_once(self) -> None:
         while not self.is_finished():
-            r, c = self.p1.choose_action(self.immutable_of(self.state()))
+            r, c = self.p1.choose_action(self.to_immutable(self.state()))
             self.play1(r, c)
-            self.p1.add_state(self.immutable_of(self.state()))
+            self.p1.add_state(self.to_immutable(self.state()))
 
             if self.is_finished():
                 break
 
-            r, c = self.p2.choose_action(self.immutable_of(self.state()))
+            r, c = self.p2.choose_action(self.to_immutable(self.state()))
             self.play2(r, c)
-            self.p2.add_state(self.immutable_of(self.state()))
+            self.p2.add_state(self.to_immutable(self.state()))
 
             if self.is_finished():
                 break
@@ -381,7 +387,7 @@ class TicTacToeMonteCarloLearner(MonteCarloLearner[TicTacToeIR, Tuple[int, int]]
 
 def _computer_play(g: TicTacToe, p: TicTacToeMonteCarloLearner):
     print(f"\n{g.show()}\n")
-    r, c = p.choose_action(g.immutable_of(g.state()), exploit=True)
+    r, c = p.choose_action(g.to_immutable(g.state()), exploit=True)
     g.play(r, c)
     print(f"\ncomputer plays at ({r}, {c})!")
 
@@ -461,11 +467,11 @@ def _many_games(
     ties = 0
     for _ in range(games):
         while not g.is_finished():
-            r, c = computer1.choose_action(g.immutable_of(g.state()), exploit=True)
+            r, c = computer1.choose_action(g.to_immutable(g.state()), exploit=True)
             g.play(r, c)
             if g.is_finished():
                 break
-            r, c = computer2.choose_action(g.immutable_of(g.state()), exploit=True)
+            r, c = computer2.choose_action(g.to_immutable(g.state()), exploit=True)
             g.play(r, c)
 
         if g.win(P1):

--- a/src/games/tictactoe/tictactoe.py
+++ b/src/games/tictactoe/tictactoe.py
@@ -322,64 +322,64 @@ class TicTacToeMonteCarloLearner(MonteCarloLearner[TicTacToeIR, Tuple[int, int]]
         return TicTacToe.applyIR(state, a)
 
 
-class TicTacToeQTrainer(TicTacToe, Trainer):
-    def __init__(self, p1: SimpleQLearner, p2: SimpleQLearner) -> None:
-        super().__init__()
-        self.p1 = p1
-        self.p2 = p2
+# class TicTacToeQTrainer(TicTacToe, Trainer):
+#     def __init__(self, p1: SimpleQLearner, p2: SimpleQLearner) -> None:
+#         super().__init__()
+#         self.p1 = p1
+#         self.p2 = p2
 
-    @override
-    def train(self, episodes=10000) -> None:
-        super().train(episodes)
+#     @override
+#     def train(self, episodes=10000) -> None:
+#         super().train(episodes)
 
-        self.p1.save_policy()
-        self.p2.save_policy()
+#         self.p1.save_policy()
+#         self.p2.save_policy()
 
-    # TODO: this training is pretty dumb, doesn't work well
-    def train_once(self) -> None:
-        while not self.is_finished():
-            ir = self.immutable_of(self.state())
-            action = self.p1.choose_action(ir)
-            r, c = action
-            self.play1(r, c)
+#     # TODO: this training is pretty dumb, doesn't work well
+#     def train_once(self) -> None:
+#         while not self.is_finished():
+#             ir = self.immutable_of(self.state())
+#             action = self.p1.choose_action(ir)
+#             r, c = action
+#             self.play1(r, c)
 
-            if self.is_finished():
-                break
+#             if self.is_finished():
+#                 break
 
-            ir = self.immutable_of(self.state())
-            action = self.p2.choose_action(ir)
-            r, c = action
-            self.play2(r, c)
+#             ir = self.immutable_of(self.state())
+#             action = self.p2.choose_action(ir)
+#             r, c = action
+#             self.play2(r, c)
 
-        if self.win(P1):
-            self.p1.update_q_value(ir, action, 1, self.immutable_of(self.state()))
-            self.p2.update_q_value(ir, action, -1, self.immutable_of(self.state()))
-        elif self.win(P2):
-            self.p1.update_q_value(ir, action, -1, self.immutable_of(self.state()))
-            self.p2.update_q_value(ir, action, 1, self.immutable_of(self.state()))
-        elif self.board_filled():
-            self.p1.update_q_value(ir, action, -0.1, self.immutable_of(self.state()))
-            self.p2.update_q_value(ir, action, 0, self.immutable_of(self.state()))
-        else:
-            raise Exception("giving rewards when game's not over. something's wrong!")
-        self.reset()
-
-
-class TicTacToeQLearner(SimpleQLearner[TicTacToeIR, Tuple[int, int]]):
-    def default_action_q_values(self) -> dict[Tuple[int, int], float]:
-        actions = {}
-        for r in range(3):
-            for c in range(3):
-                actions[(r, c)] = 0.0
-        return actions
-
-    def get_actions_from_state(self, state: TicTacToeIR) -> List[Tuple[int, int]]:
-        return [
-            (i, j) for i in range(3) for j in range(3) if state.board[i][j] == Empty
-        ]
+#         if self.win(P1):
+#             self.p1.update_q_value(ir, action, 1, self.immutable_of(self.state()))
+#             self.p2.update_q_value(ir, action, -1, self.immutable_of(self.state()))
+#         elif self.win(P2):
+#             self.p1.update_q_value(ir, action, -1, self.immutable_of(self.state()))
+#             self.p2.update_q_value(ir, action, 1, self.immutable_of(self.state()))
+#         elif self.board_filled():
+#             self.p1.update_q_value(ir, action, -0.1, self.immutable_of(self.state()))
+#             self.p2.update_q_value(ir, action, 0, self.immutable_of(self.state()))
+#         else:
+#             raise Exception("giving rewards when game's not over. something's wrong!")
+#         self.reset()
 
 
-def _computer_play(g: TicTacToe, p: TicTacToeMonteCarloLearner | TicTacToeQLearner):
+# class TicTacToeQLearner(SimpleQLearner[TicTacToeIR, Tuple[int, int]]):
+#     def default_action_q_values(self) -> dict[Tuple[int, int], float]:
+#         actions = {}
+#         for r in range(3):
+#             for c in range(3):
+#                 actions[(r, c)] = 0.0
+#         return actions
+
+#     def get_actions_from_state(self, state: TicTacToeIR) -> List[Tuple[int, int]]:
+#         return [
+#             (i, j) for i in range(3) for j in range(3) if state.board[i][j] == Empty
+#         ]
+
+
+def _computer_play(g: TicTacToe, p: TicTacToeMonteCarloLearner):
     print(f"\n{g.show()}\n")
     r, c = p.choose_action(g.immutable_of(g.state()), exploit=True)
     g.play(r, c)
@@ -405,8 +405,8 @@ def _human_play(g: TicTacToe):
 
 def _trained_game(  # noqa: C901
     g: TicTacToe,
-    computer1: TicTacToeMonteCarloLearner | TicTacToeQLearner,
-    computer2: TicTacToeMonteCarloLearner | TicTacToeQLearner,
+    computer1: TicTacToeMonteCarloLearner,
+    computer2: TicTacToeMonteCarloLearner,
 ):
     player = input(
         "play as player 1 or 2? or choose 0 to spectate computers play. "
@@ -452,8 +452,8 @@ def _trained_game(  # noqa: C901
 
 def _many_games(
     g: TicTacToe,
-    computer1: TicTacToeMonteCarloLearner | TicTacToeQLearner,
-    computer2: TicTacToeMonteCarloLearner | TicTacToeQLearner,
+    computer1: TicTacToeMonteCarloLearner,
+    computer2: TicTacToeMonteCarloLearner,
     games: int,
 ):
     x_wins = 0
@@ -503,22 +503,22 @@ def monte_carlo_many_games(games=10000):
     _many_games(g, computer1, computer2, games)
 
 
-QP1_POLICY = "src/games/tictactoe/qp1.pkl"
-QP2_POLICY = "src/games/tictactoe/qp2.pkl"
+# QP1_POLICY = "src/games/tictactoe/qp1.pkl"
+# QP2_POLICY = "src/games/tictactoe/qp2.pkl"
 
 
-def q_trained_game(training_episodes=0):
-    computer1 = TicTacToeQLearner(q_pickle=QP1_POLICY)
-    computer2 = TicTacToeQLearner(q_pickle=QP2_POLICY)
-    g = TicTacToeQTrainer(p1=computer1, p2=computer2)
-    g.train(episodes=training_episodes)
+# def q_trained_game(training_episodes=0):
+#     computer1 = TicTacToeQLearner(q_pickle=QP1_POLICY)
+#     computer2 = TicTacToeQLearner(q_pickle=QP2_POLICY)
+#     g = TicTacToeQTrainer(p1=computer1, p2=computer2)
+#     g.train(episodes=training_episodes)
 
-    _trained_game(g, computer1, computer2)
+#     _trained_game(g, computer1, computer2)
 
 
-def q_many_games(games=10000):
-    computer1 = TicTacToeQLearner(q_pickle=QP1_POLICY)
-    computer2 = TicTacToeQLearner(q_pickle=QP2_POLICY)
-    g = TicTacToeQTrainer(p1=computer1, p2=computer2)
+# def q_many_games(games=10000):
+#     computer1 = TicTacToeQLearner(q_pickle=QP1_POLICY)
+#     computer2 = TicTacToeQLearner(q_pickle=QP2_POLICY)
+#     g = TicTacToeQTrainer(p1=computer1, p2=computer2)
 
-    _many_games(g, computer1, computer2, games)
+#     _many_games(g, computer1, computer2, games)

--- a/src/games/ultimate_ttt/run.py
+++ b/src/games/ultimate_ttt/run.py
@@ -141,9 +141,7 @@ class UltimateMonteCarloTrainer(UltimateTicTacToe, Trainer):
 class UltimateMonteCarloLearner(
     MonteCarloLearner[UltimateIR, Tuple[Section, Location]]
 ):
-    def get_actions_from_state(
-        self, ir: UltimateIR
-    ) -> List[Tuple[Section, Location]]:
+    def get_actions_from_state(self, ir: UltimateIR) -> List[Tuple[Section, Location]]:
         valid_actions = UltimateTicTacToe.actions(UltimateTicTacToe.from_immutable(ir))
         return [
             UltimateTicTacToe.from_action(a)

--- a/src/games/ultimate_ttt/run.py
+++ b/src/games/ultimate_ttt/run.py
@@ -28,7 +28,6 @@ from games.ultimate_ttt.ultimate import (
     UltimateIR,
     UltimateState,
     UltimateTicTacToe,
-    ir_to_state,
 )
 from learners.alpha_zero.alpha_zero import A0Parameters, AlphaZero
 from learners.alpha_zero.monte_carlo_tree_search import MCTSParameters
@@ -105,16 +104,16 @@ class UltimateMonteCarloTrainer(UltimateTicTacToe, Trainer):
 
     def train_once(self) -> None:
         while not self.is_finished():
-            r, c = self.p1.choose_action(UltimateTicTacToe.immutable_of(self.state()))
+            r, c = self.p1.choose_action(UltimateTicTacToe.to_immutable(self.state()))
             self.play(r, c)
-            self.p1.add_state(UltimateTicTacToe.immutable_of(self.state()))
+            self.p1.add_state(UltimateTicTacToe.to_immutable(self.state()))
 
             if self.is_finished():
                 break
 
-            r, c = self.p2.choose_action(UltimateTicTacToe.immutable_of(self.state()))
+            r, c = self.p2.choose_action(UltimateTicTacToe.to_immutable(self.state()))
             self.play(r, c)
-            self.p2.add_state(UltimateTicTacToe.immutable_of(self.state()))
+            self.p2.add_state(UltimateTicTacToe.to_immutable(self.state()))
 
             if self.is_finished():
                 break
@@ -143,9 +142,9 @@ class UltimateMonteCarloLearner(
     MonteCarloLearner[UltimateIR, Tuple[Section, Location]]
 ):
     def get_actions_from_state(
-        self, state: UltimateIR
+        self, ir: UltimateIR
     ) -> List[Tuple[Section, Location]]:
-        valid_actions = UltimateTicTacToe.actions(ir_to_state(state))
+        valid_actions = UltimateTicTacToe.actions(UltimateTicTacToe.from_immutable(ir))
         return [
             UltimateTicTacToe.from_action(a)
             for a in range(len(valid_actions))
@@ -155,8 +154,8 @@ class UltimateMonteCarloLearner(
     def apply(self, ir: UltimateIR, action: Tuple[Section, Location]) -> UltimateIR:
         (sec, loc) = action
         a = UltimateTicTacToe.to_action(sec, loc)
-        s = ir_to_state(ir)
-        return UltimateTicTacToe.immutable_of(UltimateTicTacToe.apply(s, a))
+        s = UltimateTicTacToe.from_immutable(ir)
+        return UltimateTicTacToe.to_immutable(UltimateTicTacToe.apply(s, a))
 
 
 MCP1_POLICY = "src/games/ultimate_ttt/mcp1.pkl"
@@ -172,7 +171,7 @@ def monte_carlo_trained_game():
     while not g.is_finished():
         print(f"\n{g.show()}\n")
         sec, loc = computer1.choose_action(
-            UltimateTicTacToe.immutable_of(g.state()), exploit=True
+            UltimateTicTacToe.to_immutable(g.state()), exploit=True
         )
         g.play(sec, loc)
         print(f"computer X plays at section {sec} location {loc}")
@@ -181,7 +180,7 @@ def monte_carlo_trained_game():
 
         print(f"\n{g.show()}\n")
         sec, loc = computer2.choose_action(
-            UltimateTicTacToe.immutable_of(g.state()), exploit=True
+            UltimateTicTacToe.to_immutable(g.state()), exploit=True
         )
         g.play(sec, loc)
         print(f"computer O plays at section {sec} location {loc}")

--- a/src/games/ultimate_ttt/ultimate.py
+++ b/src/games/ultimate_ttt/ultimate.py
@@ -64,27 +64,6 @@ class UltimateIR(NamedTuple):
     active_nonant: Optional[Section]
 
 
-def ir_to_state(ir: UltimateIR) -> UltimateState:
-    board = np.zeros((3, 3, 3, 3))
-    for R in range(3):
-        for C in range(3):
-            if ir.board[R][C] == FinishedTTTState.XWin:
-                board[R][C] = P1
-            elif ir.board[R][C] == FinishedTTTState.OWin:
-                board[R][C] = P2
-            elif ir.board[R][C] == FinishedTTTState.Tie:
-                board[R][C] = np.asarray(
-                    [
-                        [XTile, XTile, OTile],
-                        [OTile, XTile, XTile],
-                        [XTile, OTile, OTile],
-                    ]
-                )
-            else:
-                board[R][C] = np.asarray(ir.board[R][C])
-    return UltimateState(board=board, player=ir.player, active_nonant=ir.active_nonant)
-
-
 class UltimateTicTacToe(Game[UltimateState, UltimateIR]):
     def __init__(self) -> None:
         self.reset()
@@ -229,7 +208,7 @@ class UltimateTicTacToe(Game[UltimateState, UltimateIR]):
         elif TicTacToe._is_board_filled(t):
             return FinishedTTTState.Tie
         else:
-            return TicTacToe.immutable_of(TicTacToeState(board=t, player=P1)).board
+            return TicTacToe.to_immutable(TicTacToeState(board=t, player=P1)).board
 
     @staticmethod
     def get_board_rep(board: UltimateBoard) -> UltimateBoardIR:
@@ -379,12 +358,33 @@ class UltimateTicTacToe(Game[UltimateState, UltimateIR]):
         return syms
 
     @staticmethod
-    def immutable_of(state: UltimateState) -> UltimateIR:
+    def to_immutable(state: UltimateState) -> UltimateIR:
         return UltimateIR(
             board=UltimateTicTacToe.get_board_rep(state.board),
             player=state.player,
             active_nonant=state.active_nonant,
         )
+
+    @staticmethod
+    def from_immutable(ir: UltimateIR) -> UltimateState:
+        board = np.zeros((3, 3, 3, 3))
+        for R in range(3):
+            for C in range(3):
+                if ir.board[R][C] == FinishedTTTState.XWin:
+                    board[R][C] = P1
+                elif ir.board[R][C] == FinishedTTTState.OWin:
+                    board[R][C] = P2
+                elif ir.board[R][C] == FinishedTTTState.Tie:
+                    board[R][C] = np.asarray(
+                        [
+                            [XTile, XTile, OTile],
+                            [OTile, XTile, XTile],
+                            [XTile, OTile, OTile],
+                        ]
+                    )
+                else:
+                    board[R][C] = np.asarray(ir.board[R][C])
+        return UltimateState(board=board, player=ir.player, active_nonant=ir.active_nonant)
 
     @staticmethod
     def orient_state(state: UltimateState) -> UltimateState:

--- a/src/games/ultimate_ttt/ultimate.py
+++ b/src/games/ultimate_ttt/ultimate.py
@@ -384,7 +384,9 @@ class UltimateTicTacToe(Game[UltimateState, UltimateIR]):
                     )
                 else:
                     board[R][C] = np.asarray(ir.board[R][C])
-        return UltimateState(board=board, player=ir.player, active_nonant=ir.active_nonant)
+        return UltimateState(
+            board=board, player=ir.player, active_nonant=ir.active_nonant
+        )
 
     @staticmethod
     def orient_state(state: UltimateState) -> UltimateState:

--- a/src/learners/alpha_zero/alpha_zero.py
+++ b/src/learners/alpha_zero/alpha_zero.py
@@ -6,17 +6,7 @@ from typing import Callable, Deque, Generic, List, NamedTuple, Optional, Tuple
 
 import numpy as np
 
-from games.game import (
-    P1,
-    P1WIN,
-    P2WIN,
-    Action,
-    Board,
-    Game,
-    Immutable,
-    Player,
-    State,
-)
+from games.game import P1, P1WIN, P2WIN, Action, Board, Game, Immutable, Player, State
 from learners.alpha_zero.monte_carlo_tree_search import (
     MCTSParameters,
     MonteCarloTreeSearch,

--- a/src/learners/alpha_zero/alpha_zero.py
+++ b/src/learners/alpha_zero/alpha_zero.py
@@ -1,6 +1,5 @@
 import os
 import pickle
-from abc import ABC
 from collections import deque
 from random import shuffle
 from typing import Callable, Deque, Generic, List, NamedTuple, Optional, Tuple
@@ -14,7 +13,7 @@ from games.game import (
     Action,
     Board,
     Game,
-    ImmutableRepresentation,
+    Immutable,
     Player,
     State,
 )
@@ -39,14 +38,14 @@ class A0Parameters(NamedTuple):
 # in the current scheme, (Board, Policy, Value), only captures the type of games s.t.
 # the neural network input is the board, and the output is the policy and value.
 # Other games can potentially have other input that's not fully captured in the board.
-class AlphaZero(ABC, Generic[State, ImmutableRepresentation]):
+class AlphaZero(Generic[State, Immutable]):
     """
     Combines a neural network with Monte Carlo Tree Search to increase training efficiency and reduce memory required for training.
     """
 
     def __init__(
         self,
-        game: Game[State, ImmutableRepresentation],
+        game: Game[State, Immutable],
         nn: NeuralNetwork,
         params: A0Parameters,
         m_params: MCTSParameters,

--- a/src/learners/alpha_zero/monte_carlo_tree_search.py
+++ b/src/learners/alpha_zero/monte_carlo_tree_search.py
@@ -5,7 +5,7 @@ from typing import Dict, Generic, List, NamedTuple, Tuple
 import numpy as np
 from numpy.typing import NDArray
 
-from games.game import Action, ActionStatus, Game, ImmutableRepresentation, State
+from games.game import Action, ActionStatus, Game, Immutable, State
 from nn.neural_network import NeuralNetwork
 
 
@@ -15,25 +15,25 @@ class MCTSParameters(NamedTuple):
     epsilon: float
 
 
-class MonteCarloTreeSearch(ABC, Generic[State, ImmutableRepresentation]):
+class MonteCarloTreeSearch(ABC, Generic[State, Immutable]):
     def __init__(
         self,
-        game: Game[State, ImmutableRepresentation],
+        game: Game[State, Immutable],
         nn: NeuralNetwork,
         params: MCTSParameters,
     ) -> None:
         # q values for state-action pair
-        self.q: Dict[Tuple[ImmutableRepresentation, Action], float] = {}
+        self.q: Dict[Tuple[Immutable, Action], float] = {}
         # number of times state-action pair was visited
-        self.nsa: Dict[Tuple[ImmutableRepresentation, Action], int] = {}
+        self.nsa: Dict[Tuple[Immutable, Action], int] = {}
         # number of times state was visited
-        self.ns: Dict[ImmutableRepresentation, int] = {}
+        self.ns: Dict[Immutable, int] = {}
         # value at game end, or 0 if the game is not finished yet
-        self.evs: Dict[ImmutableRepresentation, float] = {}
+        self.evs: Dict[Immutable, float] = {}
         # valid actions at a game state
-        self.vas: Dict[ImmutableRepresentation, List[ActionStatus]] = {}
+        self.vas: Dict[Immutable, List[ActionStatus]] = {}
         # the action policies at a game state
-        self.ps: Dict[ImmutableRepresentation, NDArray] = {}
+        self.ps: Dict[Immutable, NDArray] = {}
 
         self.game = game
         self.nn = nn
@@ -47,7 +47,7 @@ class MonteCarloTreeSearch(ABC, Generic[State, ImmutableRepresentation]):
         for _ in range(self.num_searches):
             self.search(state)
 
-        ir: ImmutableRepresentation = self.game.immutable_of(state)
+        ir: Immutable = self.game.immutable_of(state)
         sa_visits = [
             self.nsa[(ir, a)] if (ir, a) in self.nsa else 0
             for a in range(self.game.num_actions())

--- a/src/learners/alpha_zero/monte_carlo_tree_search.py
+++ b/src/learners/alpha_zero/monte_carlo_tree_search.py
@@ -47,7 +47,7 @@ class MonteCarloTreeSearch(ABC, Generic[State, Immutable]):
         for _ in range(self.num_searches):
             self.search(state)
 
-        ir: Immutable = self.game.immutable_of(state)
+        ir: Immutable = self.game.to_immutable(state)
         sa_visits = [
             self.nsa[(ir, a)] if (ir, a) in self.nsa else 0
             for a in range(self.game.num_actions())
@@ -68,7 +68,7 @@ class MonteCarloTreeSearch(ABC, Generic[State, Immutable]):
         return [v / total_visits for v in visits]
 
     def search(self, state: State) -> float:
-        ir = self.game.immutable_of(state)
+        ir = self.game.to_immutable(state)
 
         if ir not in self.evs:
             self.evs[ir] = (

--- a/src/learners/q.py
+++ b/src/learners/q.py
@@ -1,82 +1,98 @@
 import os
 import pickle
 import random
-from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import Generic, List, Tuple, TypeVar
+from typing import Generic, List, NamedTuple, Tuple, TypeVar
 
-StateType = TypeVar("StateType")
-ActionType = TypeVar("ActionType")
+from games.game import VALID, Action, Game, Immutable, State
 
 
-class SimpleQLearner(Generic[StateType, ActionType], ABC):
+class SimpleQParameters(NamedTuple):
+    alpha: float  # learning rate
+    gamma: float  # reward decay rate
+    epsilon: float  # explore rate
+
+class SimpleQLearner(Generic[State, Immutable]):
     """
     A default Q Learner that uses default dictionaries to track the Q table. Works for simple games.
     For complex games, we probably need to serialize the states/actions so learning can be more efficient.
     """
 
-    def __init__(self, q_pickle: str = "", alpha=0.1, gamma=0.9, epsilon=0.1) -> None:
+    def __init__(self, game: Game[State, Immutable], params: SimpleQParameters, q_pickle: str = "") -> None:
+        self.game = game
+
         self.q_pickle = q_pickle
-        self.q_table: defaultdict[StateType, dict[ActionType, float]] = defaultdict(
+        self.q_table: defaultdict[Immutable, dict[Action, float]] = defaultdict(
             self.default_action_q_values  # TODO: pickle can't find this if refactored
         )
         if self.q_pickle and os.path.isfile(self.q_pickle):
             with open(self.q_pickle, "rb") as file:
                 self.q_table = pickle.load(file)
-        self.alpha = alpha  # learning rate
-        self.gamma = gamma  # reward decay rate
-        self.epsilon = epsilon  # explore rate
+        
+        self.alpha = params.alpha
+        self.gamma = params.gamma
+        self.epsilon = params.epsilon
 
-    @abstractmethod
-    def default_action_q_values(self) -> dict[ActionType, float]:
+    def default_action_q_values(self) -> dict[Action, float]:
         """
-        Gets an enumeration of all actions to a default q-value (probably 0.0). Assumes that the possible actions are always the same at each state.
+        Gets an enumeration of all actions to a default q-value of 0.0. Assumes that the possible actions are always the same at each state.
         """
-        pass
+        d = {}
+        for a in range(self.game.num_actions()):
+            d[a] = 0.0
+        return d
 
     # TODO: maybe extract choose_action to a learner or agent class
-    def choose_action(self, state: StateType, exploit: bool = False) -> ActionType:
+    def choose_action(self, state: State, exploit: bool = False) -> Action:
+        ir = self.game.immutable_of(state)
         legal_actions = self.get_actions_from_state(state)
         if random.uniform(0, 1) < self.epsilon and not exploit:
             return random.choice(legal_actions)
         else:
             # max() takes the first item if there are ties, so sometimes we can get stuck in a cycle of always choosing one action
-            actions_q_vals: List[Tuple[ActionType, float]] = [
-                (a, q) for (a, q) in self.q_table[state].items() if a in legal_actions
+            actions_q_vals: List[Tuple[Action, float]] = [
+                (a, q) for (a, q) in self.q_table[ir].items() if a in legal_actions
             ]
             (_, best_q) = max(actions_q_vals, key=lambda x: x[1])
-            best_actions: List[ActionType] = [
+            best_actions: List[Action] = [
                 a for (a, q) in actions_q_vals if q == best_q
             ]
             return random.choice(best_actions)
 
     def update_q_value(
-        self, state: StateType, action: ActionType, reward: float, next_state: StateType
+        self, state: State, action: Action, reward: float, next_state: State
     ) -> None:
+        ir = self.game.immutable_of(state)
+        next_ir = self.game.immutable_of(next_state)
+
         next_actions = self.get_actions_from_state(next_state)
         if next_actions:
             random_action = random.choice(self.get_actions_from_state(next_state))
             best_next_action = max(
-                self.q_table[next_state],
-                key=self.q_table[next_state].__getitem__,
+                self.q_table[next_ir],
+                key=self.q_table[next_ir].__getitem__,
                 default=random_action,
             )
-            next_q_value = self.q_table[next_state][best_next_action]
+            next_q_value = self.q_table[next_ir][best_next_action]
         else:
             # if next_state is a terminal state (game end), then the best next q value is...?
             # TODO: does 0.0 work? if so, what does it say about how the reward function should be structured?
             next_q_value = 0.0
-        current_q_value = self.q_table[state][action]
-        self.q_table[state][action] = (
+        current_q_value = self.q_table[ir][action]
+        self.q_table[ir][action] = (
             1 - self.alpha
         ) * current_q_value + self.alpha * (reward + self.gamma * next_q_value)
 
-    @abstractmethod
-    def get_actions_from_state(self, state: StateType) -> List[ActionType]:
+    def get_actions_from_state(self, state: State) -> List[Action]:
         """
         Gets a list of legal actions from a state
         """
-        pass
+        legals = []
+        actions = self.game.actions(state)
+        for (a, status) in enumerate(actions):
+            if status == VALID:
+                legals.append(a)
+        return legals
 
     def save_policy(self) -> None:
         if self.q_pickle:

--- a/src/learners/q.py
+++ b/src/learners/q.py
@@ -12,7 +12,9 @@ class SimpleQParameters(NamedTuple):
     gamma: float  # reward decay rate
     epsilon: float  # explore rate
 
+
 DefaultQParams = SimpleQParameters(alpha=0.1, gamma=0.9, epsilon=0.1)
+
 
 class SimpleQLearner(Generic[State, Immutable]):
     """
@@ -20,7 +22,12 @@ class SimpleQLearner(Generic[State, Immutable]):
     For complex games, we probably need to serialize the states/actions so learning can be more efficient.
     """
 
-    def __init__(self, game: Game[State, Immutable], q_pickle: str = "", params: SimpleQParameters = DefaultQParams) -> None:
+    def __init__(
+        self,
+        game: Game[State, Immutable],
+        q_pickle: str = "",
+        params: SimpleQParameters = DefaultQParams,
+    ) -> None:
         self.game = game
 
         self.q_pickle = q_pickle
@@ -30,7 +37,7 @@ class SimpleQLearner(Generic[State, Immutable]):
         if self.q_pickle and os.path.isfile(self.q_pickle):
             with open(self.q_pickle, "rb") as file:
                 self.q_table = pickle.load(file)
-        
+
         self.alpha = params.alpha
         self.gamma = params.gamma
         self.epsilon = params.epsilon
@@ -54,9 +61,7 @@ class SimpleQLearner(Generic[State, Immutable]):
                 (a, q) for (a, q) in self.q_table[ir].items() if a in legal_actions
             ]
             (_, best_q) = max(actions_q_vals, key=lambda x: x[1])
-            best_actions: List[Action] = [
-                a for (a, q) in actions_q_vals if q == best_q
-            ]
+            best_actions: List[Action] = [a for (a, q) in actions_q_vals if q == best_q]
             return random.choice(best_actions)
 
     def update_q_value(
@@ -76,9 +81,9 @@ class SimpleQLearner(Generic[State, Immutable]):
             # TODO: does 0.0 work? if so, what does it say about how the reward function should be structured?
             next_q_value = 0.0
         current_q_value = self.q_table[ir][action]
-        self.q_table[ir][action] = (
-            1 - self.alpha
-        ) * current_q_value + self.alpha * (reward + self.gamma * next_q_value)
+        self.q_table[ir][action] = (1 - self.alpha) * current_q_value + self.alpha * (
+            reward + self.gamma * next_q_value
+        )
 
     def get_actions_from_state(self, ir: Immutable) -> List[Action]:
         """
@@ -86,7 +91,7 @@ class SimpleQLearner(Generic[State, Immutable]):
         """
         legals = []
         actions = self.game.actions(self.game.from_immutable(ir))
-        for (a, status) in enumerate(actions):
+        for a, status in enumerate(actions):
             if status == VALID:
                 legals.append(a)
         return legals


### PR DESCRIPTION
The current simple Q and MonteCarlo learners use inheritance to implement the game specific nuances that it's training. I'm not the biggest fan of inheritance and being able to compose the games along with the learners instead feels a lot cleaner. This branch is an attempt to do that. However, the result is a bit clumsy, so just leaving it in a branch for now.

I think it'd help to write out each use case. The current learners are the simple Q learner, Monte Carlo, and Alpha Zero. Each has slightly different usages of the games that it trains on, so it's tough to generalize everything, or at least, it would require more thought and planning.