### PR TITLE
Refactor Digit Party DQN and add 5x5 training path

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -49,7 +49,33 @@ def _define_parser() -> argparse.ArgumentParser:
         aliases=["dpdq", "dp_deep_q"],
         help="run digit party with deep q learning",
     )
-    sub_digit_party_deep_q.set_defaults(function=digit_party_deep_q.main)
+    sub_digit_party_deep_q.add_argument(
+        "--size",
+        choices=["3", "5"],
+        default="3",
+        help="digit party board size to run",
+    )
+    sub_digit_party_deep_q.add_argument(
+        "--mode",
+        choices=["train", "eval-best"],
+        default="eval-best",
+        help="train agent or evaluate best saved model",
+    )
+    sub_digit_party_deep_q.add_argument(
+        "--games",
+        type=int,
+        default=1000,
+        help="number of evaluation games to run",
+    )
+    sub_digit_party_deep_q.add_argument(
+        "--episodes",
+        type=int,
+        default=None,
+        help="optional training episode override",
+    )
+    sub_digit_party_deep_q.set_defaults(
+        function=digit_party_deep_q.main, pass_args=True
+    )
 
     return parser
 
@@ -57,4 +83,7 @@ def _define_parser() -> argparse.ArgumentParser:
 def run() -> None:
     parser = _define_parser()
     args = parser.parse_args()
-    args.function()
+    if getattr(args, "pass_args", False):
+        args.function(args)
+    else:
+        args.function()

--- a/src/games/digit_party/DQN_5X5_PLAN.md
+++ b/src/games/digit_party/DQN_5X5_PLAN.md
@@ -1,0 +1,163 @@
+# Digit Party 5x5 Deep Q Plan
+
+This is the first-pass plan for training a `5x5` Digit Party deep q model.
+
+The point is not to invent a huge new architecture. The point is to take what finally worked on `3x3`, scale it up carefully, and give it enough training to matter.
+
+## Baseline To Copy From
+
+The `3x3` deep q setup that actually worked uses:
+
+- board input plus current digit plus next digit
+- a simple conv stack
+- a single linear q-value head
+- `epochs=1` per replay update
+- masked legal actions
+- small, frequent replay updates
+- a target network
+- enough evaluation and checkpointing to trust the run
+
+That is still the right basic shape for `5x5`.
+
+## Final Recommendation
+
+### Network Architecture
+
+Use:
+
+- board input: `5x5`
+- current digit input: scalar
+- next digit input: scalar
+- normalize board and visible digits by the max digit for the board size
+- `8` conv layers
+- `24` conv filters
+- `3x3` kernels
+- `1` dense layer
+- `512` dense units
+- `dropout_rate=0.0`
+- `epochs=1`
+- `batch_size=128`
+- `learning_rate=0.00075`
+- linear q-value output with `25` actions
+
+Keep the current digit and next digit concatenated after flattening for the first pass. That keeps the implementation close to the `3x3` path.
+
+There is still a good follow-up idea to try later:
+
+- broadcast current digit and next digit as extra `5x5` planes before the conv stack
+
+That would let the spatial filters condition on digit context earlier. It is a good next architectural experiment, but not the first one.
+
+### Training Schedule
+
+Use:
+
+- `alpha=0.1`
+- `gamma=0.95`
+- `min_epsilon=0.05`
+- `max_epsilon=1.0`
+- `epsilon_decay=0.00002`
+- `valid_action_reward=0.01`
+- `memory_size=500_000`
+- `min_replay_size=25_000`
+- `minibatch_size=128`
+- `steps_to_train_longterm=4`
+- `steps_to_train_shortterm=0`
+- `steps_per_target_update=500`
+- `training_episodes=500_000`
+- `episodes_per_model_save=10_000`
+- `episodes_per_memory_save=10_000`
+- `episodes_per_stats_print=1_000`
+- `episodes_per_evaluation=5_000`
+- training evaluation over `250` games
+- final evaluation over `1000` games
+- `state_tracker_size_bits=67_108_864`
+- `state_tracker_num_hashes=7`
+
+## Why This Is Not A Huge Network
+
+The raw state space blows up far faster than the network size should.
+
+That is because the network is not trying to memorize every possible `5x5` state. If it had to do that, the problem would be hopeless. The whole point of the conv net is to learn reusable local scoring rules:
+
+- matching neighbors
+- cluster growth
+- edge and corner effects
+- when the current digit should be placed greedily
+- when a low immediate score is worth it for future structure
+
+So the architecture should scale with:
+
+- board geometry
+- number of candidate actions
+- richness of local patterns
+
+not with:
+
+- the full combinatorial state count
+
+## Why This Is Still A Large Step Up From 3x3
+
+Even though this looks like a small architectural change on paper, it is not small in practice.
+
+Compared to the `3x3` run:
+
+- actions go from `9` to `25`
+- episode length goes from `9` moves to `25`
+- max digit goes from `4` to `9`
+- replay memory gets `5x` bigger
+- minibatch goes from `64` to `128`
+- target sync interval gets looser in episode terms but still regular in step terms
+- epsilon decays much more slowly
+
+The training budget increase matters even more than the network increase.
+
+Roughly:
+
+- `3x3`: `200,000` episodes is about `1.8M` environment steps
+- `5x5`: `500,000` episodes is about `12.5M` environment steps
+
+That is about `7x` more interaction, which is more in line with how much harder `5x5` is.
+
+## Why Normalize By Max Digit
+
+For `3x3`, digits go up to `4`.
+
+For `5x5`, digits go up to `9`.
+
+If the network sees raw values, then moving from `3x3` to `5x5` changes the numeric input scale a lot. Normalizing by the max digit keeps inputs in a more stable range like `[0, 1]`.
+
+That helps because:
+
+- optimization is usually easier with bounded inputs
+- the `3x3` and `5x5` setups become more comparable
+- the model spends less effort adapting to raw value scale
+
+This is a very cheap change and it is worth doing.
+
+## What Not To Add Yet
+
+Do not start with:
+
+- residual blocks
+- dueling DQN
+- prioritized replay
+- one-hot digit channels
+- a second value head
+- a much deeper or much wider model than this
+
+Those may be worth trying later, but they make failure harder to interpret.
+
+## Simple Read Of The Plan
+
+The first `5x5` attempt should be:
+
+- the same deep q setup that finally worked on `3x3`
+- a moderately larger conv net
+- normalized inputs
+- much slower exploration decay
+- much longer training
+
+If that does not move clearly above random, then the next architectural thing to try is not "make it huge". The next thing to try is:
+
+- give the conv stack earlier access to the current digit and next digit by turning them into input planes

--- a/src/games/digit_party/deep_q_common.py
+++ b/src/games/digit_party/deep_q_common.py
@@ -1,0 +1,205 @@
+import pathlib
+from typing import NamedTuple
+
+import numpy as np
+from keras.models import Model  # type: ignore
+
+from games.digit_party.game import DigitParty, DigitPartyPlacement, DigitPartyState
+from games.digit_party.run_helpers import computer_game
+from games.game import VALID
+from learners.deep_q import DeepQLearner, DeepQParameters, DQNOutput, EvaluationResult
+from nn.neural_network import NeuralNetwork
+
+
+class DigitPartyEvaluation(NamedTuple):
+    games: int
+    average_pct: float
+    aggregate_pct: float
+    average_score: float
+    average_theoretical_max: float
+
+
+class BaseDigitPartyDeepQNN(NeuralNetwork[DigitPartyState, DQNOutput]):
+    def __init__(
+        self,
+        model_folder: str,
+        batch_size: int,
+        epochs: int,
+        normalize_scale: float = 1.0,
+    ) -> None:
+        super().__init__(model_folder)
+        self.batch_size = batch_size
+        self.epochs = epochs
+        self.normalize_scale = normalize_scale
+        self.model: Model
+
+    def _model_inputs(
+        self, inputs: list[DigitPartyState]
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        input_boards = np.asarray(
+            [input.board / self.normalize_scale for input in inputs], dtype=float
+        )
+        input_currs = np.asarray(
+            [
+                (input.next[0] if input.next[0] is not None else 0)
+                / self.normalize_scale
+                for input in inputs
+            ],
+            dtype=float,
+        )
+        input_nexts = np.asarray(
+            [
+                (input.next[1] if input.next[1] is not None else 0)
+                / self.normalize_scale
+                for input in inputs
+            ],
+            dtype=float,
+        )
+        return input_boards, input_currs, input_nexts
+
+    def train(self, data: list[tuple[DigitPartyState, DQNOutput]]) -> None:
+        inputs: list[DigitPartyState]
+        outputs: list[DQNOutput]
+        inputs, outputs = list(zip(*data))
+        input_boards, input_currs, input_nexts = self._model_inputs(list(inputs))
+        target_qs = np.asarray([output.policy for output in outputs])
+        self.model.fit(
+            x=[input_boards, input_currs, input_nexts],
+            y=target_qs,
+            batch_size=self.batch_size,
+            epochs=self.epochs,
+            shuffle=True,
+            verbose=0,
+        )
+
+    def predict(self, inputs: list[DigitPartyState]) -> list[DQNOutput]:
+        input_boards, input_currs, input_nexts = self._model_inputs(inputs)
+        qs = self.model.predict([input_boards, input_currs, input_nexts], verbose=0)
+        return [DQNOutput(policy=q, value=0.0) for q in qs]
+
+    def save(self, file: str) -> None:
+        model_path = pathlib.Path(self.model_folder)
+        if not model_path.exists():
+            print(f"Making directory for models at: {self.model_folder}")
+            model_path.mkdir(parents=True)
+        self.model.save_weights(model_path / file)
+
+    def load(self, file: str) -> None:
+        self.model.load_weights(pathlib.Path(self.model_folder) / file)
+
+    def set_weights(self, weights) -> None:
+        self.model.set_weights(weights)
+
+    def get_weights(self):
+        return self.model.get_weights()
+
+    def summary(self) -> None:
+        self.model.summary()
+
+
+def greedy_digit_party_move(
+    nn: NeuralNetwork[DigitPartyState, DQNOutput], state: DigitPartyState
+) -> DigitPartyPlacement:
+    out = nn.predict([state])[0]
+    valid_actions = np.flatnonzero(np.asarray(DigitParty.actions(state)) == VALID)
+    if len(valid_actions) == 0:
+        raise ValueError("No valid actions are available for Digit Party evaluation")
+
+    action = int(valid_actions[int(np.argmax(out.policy[valid_actions]))])
+    n = state.board.shape[0]
+    return int(action / n), int(action % n)
+
+
+def evaluate_digit_party(
+    nn: NeuralNetwork[DigitPartyState, DQNOutput], games: int, n: int
+) -> DigitPartyEvaluation:
+    game = DigitParty(n=n)
+    total_score = 0.0
+    total_theoretical_max = 0.0
+    total_pct = 0.0
+
+    for _ in range(games):
+        game.reset()
+        while not game.is_finished():
+            r, c = greedy_digit_party_move(nn, game.state())
+            game.place(r, c)
+
+        score = float(game.score)
+        theoretical_max = float(game.theoretical_max_score())
+        total_score += score
+        total_theoretical_max += theoretical_max
+        total_pct += score / theoretical_max if theoretical_max > 0 else 0.0
+
+    return DigitPartyEvaluation(
+        games=games,
+        average_pct=100 * total_pct / games,
+        aggregate_pct=100 * total_score / total_theoretical_max,
+        average_score=total_score / games,
+        average_theoretical_max=total_theoretical_max / games,
+    )
+
+
+def digit_party_evaluation_summary(
+    nn: NeuralNetwork[DigitPartyState, DQNOutput], games: int, n: int
+) -> EvaluationResult:
+    evaluation = evaluate_digit_party(nn=nn, games=games, n=n)
+    return EvaluationResult(
+        score=evaluation.average_pct,
+        summary=(
+            f"{evaluation.games} games, "
+            f"avg_pct={evaluation.average_pct:.2f}%, "
+            f"aggregate_pct={evaluation.aggregate_pct:.2f}%, "
+            f"avg_score={evaluation.average_score:.2f}/"
+            f"{evaluation.average_theoretical_max:.2f}"
+        ),
+    )
+
+
+def train_digit_party_dqn(
+    n: int,
+    nn: NeuralNetwork[DigitPartyState, DQNOutput],
+    target_nn: NeuralNetwork[DigitPartyState, DQNOutput],
+    params: DeepQParameters,
+    training_artifacts_folder: str,
+    eval_games: int,
+    final_eval_games: int,
+    episodes_override: int | None = None,
+) -> None:
+    if episodes_override is not None:
+        params = params._replace(training_episodes=episodes_override)
+
+    nn.summary()
+    deepq = DeepQLearner(
+        DigitParty(n=n),
+        nn,
+        target_nn,
+        params,
+        training_artifacts_folder=training_artifacts_folder,
+        evaluator=lambda: digit_party_evaluation_summary(nn=nn, games=eval_games, n=n),
+    )
+    deepq.train()
+
+    print(
+        "Final evaluation: "
+        + digit_party_evaluation_summary(nn=nn, games=final_eval_games, n=n).summary
+    )
+
+
+def eval_best_digit_party_dqn(
+    n: int,
+    nn: NeuralNetwork[DigitPartyState, DQNOutput],
+    best_model_file: str,
+    games: int,
+) -> None:
+    if not pathlib.Path(best_model_file).exists():
+        raise FileNotFoundError(
+            f"Could not find trained best model at {best_model_file}"
+        )
+
+    nn.load(best_model_file)
+    print(f"Loaded best model from: {best_model_file}")
+    computer_game(
+        DigitParty(n=n),
+        games,
+        lambda state: greedy_digit_party_move(nn, state),
+    )

--- a/src/games/digit_party/train_q_deep.py
+++ b/src/games/digit_party/train_q_deep.py
@@ -68,6 +68,10 @@ class DigitParty3x3DeepQNN(NeuralNetwork[DigitPartyState, DQNOutput]):
             )(prev)
 
         flat = Flatten()(prev)
+        # TODO(digit-party-5x5): try broadcasting current/next digits as extra
+        # 2D planes before the conv stack instead of appending them here as
+        # scalars. That would let spatial filters condition on digit context
+        # earlier in the network.
         prev = Concatenate()([flat, input_curr_digit, input_next_digit])
 
         for _ in range(self.params.dense_layers):

--- a/src/games/digit_party/train_q_deep.py
+++ b/src/games/digit_party/train_q_deep.py
@@ -1,264 +1,36 @@
-import pathlib
-from typing import NamedTuple
+from types import SimpleNamespace
+from typing import Protocol, cast
 
-import numpy as np
-from keras.layers import (  # type: ignore
-    Concatenate,
-    Conv2D,
-    Dense,
-    Flatten,
-    Input,
-    Reshape,
-)
-from keras.models import Model  # type: ignore
-from keras.optimizers import Adam  # type: ignore
-
-from games.digit_party.game import DigitParty, DigitPartyPlacement, DigitPartyState
-from games.digit_party.run_helpers import computer_game
-from games.digit_party.train_deep import DP3NNParams
-from games.game import VALID
-from learners.deep_q import DeepQLearner, DeepQParameters, DQNOutput, EvaluationResult
-from nn.neural_network import NeuralNetwork
-
-"""Trains a 3x3 Digit Party network with a DQN-focused architecture baseline."""
-
-# Temporary DQN baseline.
-DQN_3X3_NN_PARAMS = DP3NNParams(
-    conv_layers=8,
-    conv_filters=14,
-    dense_layers=1,
-    dense_units=337,
-    learning_rate=0.0009647204266707786,
-    batch_size=64,
-    epochs=1,
-    dropout_rate=0.0,
-    output_activation="linear",
-)
-
-MODELS_FOLDER = "deepq_3x3_models"
-ARTIFACTS_FOLDER = "deepq_3x3_artifacts"
+from games.digit_party.train_q_deep_3x3 import eval_3x3_best, train_3x3_dqn
+from games.digit_party.train_q_deep_5x5 import eval_5x5_best, train_5x5_dqn
 
 
-class DigitPartyEvaluation(NamedTuple):
+class DeepQCLIArgs(Protocol):
+    size: str
+    mode: str
     games: int
-    average_pct: float
-    aggregate_pct: float
-    average_score: float
-    average_theoretical_max: float
+    episodes: int | None
 
 
-class DigitParty3x3DeepQNN(NeuralNetwork[DigitPartyState, DQNOutput]):
-    def __init__(self, params: DP3NNParams, model_folder: str) -> None:
-        super().__init__(model_folder)
-        self.params = params
+deep_q_3x3_trained_game = train_3x3_dqn
+best_model_game = eval_3x3_best
 
-        input_board = Input(shape=(3, 3), name="dp_3x3_board")
-        input_curr_digit = Input(shape=(1,), name="current_digit")
-        input_next_digit = Input(shape=(1,), name="next_digit")
 
-        board = Reshape((3, 3, 1))(input_board)
-        prev = board
-
-        for _ in range(self.params.conv_layers):
-            prev = Conv2D(
-                filters=self.params.conv_filters,
-                kernel_size=(2, 2),
-                padding="same",
-                activation="relu",
-            )(prev)
-
-        flat = Flatten()(prev)
-        # TODO(digit-party-5x5): try broadcasting current/next digits as extra
-        # 2D planes before the conv stack instead of appending them here as
-        # scalars. That would let spatial filters condition on digit context
-        # earlier in the network.
-        prev = Concatenate()([flat, input_curr_digit, input_next_digit])
-
-        for _ in range(self.params.dense_layers):
-            prev = Dense(self.params.dense_units, activation="relu")(prev)
-
-        q_values = Dense(9, activation=self.params.output_activation, name="q")(prev)
-
-        self.model = Model(
-            inputs=[input_board, input_curr_digit, input_next_digit], outputs=q_values
-        )
-        self.model.compile(
-            loss="mean_squared_error",
-            optimizer=Adam(learning_rate=self.params.learning_rate),
+def main(args: DeepQCLIArgs | None = None) -> None:
+    if args is None:
+        args = cast(
+            DeepQCLIArgs,
+            SimpleNamespace(size="3", mode="eval-best", games=1000, episodes=None),
         )
 
-    def train(self, data: list[tuple[DigitPartyState, DQNOutput]]) -> None:
-        inputs: list[DigitPartyState]
-        outputs: list[DQNOutput]
-        inputs, outputs = list(zip(*data))
-        input_boards = np.asarray([input.board for input in inputs])
-        input_currs = np.asarray(
-            [input.next[0] if input.next[0] is not None else 0 for input in inputs]
-        )
-        input_nexts = np.asarray(
-            [input.next[1] if input.next[1] is not None else 0 for input in inputs]
-        )
-        target_qs = np.asarray([output.policy for output in outputs])
-        self.model.fit(
-            x=[input_boards, input_currs, input_nexts],
-            y=target_qs,
-            batch_size=self.params.batch_size,
-            epochs=self.params.epochs,
-            shuffle=True,
-            verbose=0,
-        )
+    if args.size == "3":
+        if args.mode == "train":
+            train_3x3_dqn(episodes=args.episodes)
+        else:
+            eval_3x3_best(games=args.games)
+        return
 
-    def predict(self, inputs: list[DigitPartyState]) -> list[DQNOutput]:
-        input_boards = np.asarray([input.board for input in inputs])
-        input_currs = np.asarray(
-            [input.next[0] if input.next[0] is not None else 0 for input in inputs]
-        )
-        input_nexts = np.asarray(
-            [input.next[1] if input.next[1] is not None else 0 for input in inputs]
-        )
-        qs = self.model.predict([input_boards, input_currs, input_nexts], verbose=0)
-        return [DQNOutput(policy=q, value=0.0) for q in qs]
-
-    def save(self, file: str) -> None:
-        model_path = pathlib.Path(self.model_folder)
-        if not model_path.exists():
-            print(f"Making directory for models at: {self.model_folder}")
-            model_path.mkdir(parents=True)
-        self.model.save_weights(model_path / file)
-
-    def load(self, file: str) -> None:
-        self.model.load_weights(pathlib.Path(self.model_folder) / file)
-
-    def set_weights(self, weights) -> None:
-        self.model.set_weights(weights)
-
-    def get_weights(self):
-        return self.model.get_weights()
-
-    def summary(self) -> None:
-        self.model.summary()
-
-
-def greedy_digit_party_move(
-    nn: NeuralNetwork[DigitPartyState, DQNOutput], state: DigitPartyState
-) -> DigitPartyPlacement:
-    out = nn.predict([state])[0]
-    valid_actions = np.flatnonzero(np.asarray(DigitParty.actions(state)) == VALID)
-    if len(valid_actions) == 0:
-        raise ValueError("No valid actions are available for Digit Party evaluation")
-
-    action = int(valid_actions[int(np.argmax(out.policy[valid_actions]))])
-    n = state.board.shape[0]
-    return int(action / n), int(action % n)
-
-
-def evaluate_digit_party(
-    nn: NeuralNetwork[DigitPartyState, DQNOutput], games: int, n: int
-) -> DigitPartyEvaluation:
-    game = DigitParty(n=n)
-    total_score = 0.0
-    total_theoretical_max = 0.0
-    total_pct = 0.0
-
-    for _ in range(games):
-        game.reset()
-        while not game.is_finished():
-            r, c = greedy_digit_party_move(nn, game.state())
-            game.place(r, c)
-
-        score = float(game.score)
-        theoretical_max = float(game.theoretical_max_score())
-        total_score += score
-        total_theoretical_max += theoretical_max
-        total_pct += score / theoretical_max if theoretical_max > 0 else 0.0
-
-    return DigitPartyEvaluation(
-        games=games,
-        average_pct=100 * total_pct / games,
-        aggregate_pct=100 * total_score / total_theoretical_max,
-        average_score=total_score / games,
-        average_theoretical_max=total_theoretical_max / games,
-    )
-
-
-def digit_party_evaluation_summary(
-    nn: NeuralNetwork[DigitPartyState, DQNOutput], games: int, n: int
-) -> EvaluationResult:
-    evaluation = evaluate_digit_party(nn=nn, games=games, n=n)
-    return EvaluationResult(
-        score=evaluation.average_pct,
-        summary=(
-            f"{evaluation.games} games, "
-            f"avg_pct={evaluation.average_pct:.2f}%, "
-            f"aggregate_pct={evaluation.aggregate_pct:.2f}%, "
-            f"avg_score={evaluation.average_score:.2f}/"
-            f"{evaluation.average_theoretical_max:.2f}"
-        ),
-    )
-
-
-def deep_q_3x3_trained_game():
-    cur_dir = pathlib.Path(__file__).parent.resolve()
-    nn = DigitParty3x3DeepQNN(
-        params=DQN_3X3_NN_PARAMS, model_folder=f"{cur_dir}/{MODELS_FOLDER}/"
-    )
-    target_nn = DigitParty3x3DeepQNN(
-        params=DQN_3X3_NN_PARAMS, model_folder=f"{cur_dir}/{MODELS_FOLDER}/"
-    )
-    nn.summary()
-    deepq = DeepQLearner(
-        DigitParty(n=3),
-        nn,
-        target_nn,
-        DeepQParameters(
-            alpha=0.1,
-            gamma=0.9,
-            min_epsilon=0.05,
-            max_epsilon=1,
-            epsilon_decay=0.0001,
-            valid_action_reward=0.01,
-            memory_size=100_000,
-            min_replay_size=5_000,
-            minibatch_size=64,
-            steps_to_train_longterm=4,
-            steps_to_train_shortterm=0,
-            steps_per_target_update=250,
-            training_episodes=200_000,
-            episodes_per_model_save=5_000,
-            episodes_per_memory_save=5_000,
-            episodes_per_stats_print=500,
-            episodes_per_evaluation=2500,
-            state_tracker_size_bits=16_777_216,
-            state_tracker_num_hashes=7,
-        ),
-        training_artifacts_folder=f"{cur_dir}/{ARTIFACTS_FOLDER}/",
-        evaluator=lambda: digit_party_evaluation_summary(nn=nn, games=500, n=3),
-    )
-    deepq.train()
-
-    print(
-        "Final evaluation: "
-        + digit_party_evaluation_summary(nn=nn, games=1000, n=3).summary
-    )
-
-
-def best_model_game(games: int = 1000) -> None:
-    cur_dir = pathlib.Path(__file__).parent.resolve()
-    model_folder = f"{cur_dir}/{MODELS_FOLDER}"
-    model_file = f"{model_folder}/best_model.weights.h5"
-    if not pathlib.Path(model_file).exists():
-        raise FileNotFoundError(f"Could not find trained best model at {model_file}")
-
-    nn = DigitParty3x3DeepQNN(params=DQN_3X3_NN_PARAMS, model_folder=f"{model_folder}/")
-    nn.load(model_file)
-    print(f"Loaded best model from: {model_file}")
-    computer_game(
-        DigitParty(n=3),
-        games,
-        lambda state: greedy_digit_party_move(nn, state),
-    )
-
-
-def main() -> None:
-    # deep_q_3x3_trained_game()
-    best_model_game(games=1000)
+    if args.mode == "train":
+        train_5x5_dqn(episodes=args.episodes)
+    else:
+        eval_5x5_best(games=args.games)

--- a/src/games/digit_party/train_q_deep_3x3.py
+++ b/src/games/digit_party/train_q_deep_3x3.py
@@ -1,0 +1,146 @@
+import pathlib
+
+from keras.layers import (  # type: ignore
+    Concatenate,
+    Conv2D,
+    Dense,
+    Flatten,
+    Input,
+    Reshape,
+)
+from keras.models import Model  # type: ignore
+from keras.optimizers import Adam  # type: ignore
+
+from games.digit_party.deep_q_common import (
+    BaseDigitPartyDeepQNN,
+    eval_best_digit_party_dqn,
+    train_digit_party_dqn,
+)
+from games.digit_party.train_deep import DP3NNParams
+from learners.deep_q import DeepQParameters
+
+"""Trains a 3x3 Digit Party network with a DQN-focused architecture baseline."""
+
+DQN_3X3_NN_PARAMS = DP3NNParams(
+    conv_layers=8,
+    conv_filters=14,
+    dense_layers=1,
+    dense_units=337,
+    learning_rate=0.0009647204266707786,
+    batch_size=64,
+    epochs=1,
+    dropout_rate=0.0,
+    output_activation="linear",
+)
+
+DQN_3X3_PARAMS = DeepQParameters(
+    alpha=0.1,
+    gamma=0.9,
+    min_epsilon=0.05,
+    max_epsilon=1,
+    epsilon_decay=0.0001,
+    valid_action_reward=0.01,
+    memory_size=100_000,
+    min_replay_size=5_000,
+    minibatch_size=64,
+    steps_to_train_longterm=4,
+    steps_to_train_shortterm=0,
+    steps_per_target_update=250,
+    training_episodes=200_000,
+    episodes_per_model_save=5_000,
+    episodes_per_memory_save=5_000,
+    episodes_per_stats_print=500,
+    episodes_per_evaluation=2500,
+    state_tracker_size_bits=16_777_216,
+    state_tracker_num_hashes=7,
+)
+
+MODELS_FOLDER = "deepq_3x3_models"
+ARTIFACTS_FOLDER = "deepq_3x3_artifacts"
+TRAINING_EVAL_GAMES = 500
+FINAL_EVAL_GAMES = 1000
+
+
+class DigitParty3x3DeepQNN(BaseDigitPartyDeepQNN):
+    def __init__(self, params: DP3NNParams, model_folder: str) -> None:
+        super().__init__(
+            model_folder=model_folder,
+            batch_size=params.batch_size,
+            epochs=params.epochs,
+            normalize_scale=1.0,
+        )
+        self.params = params
+
+        input_board = Input(shape=(3, 3), name="dp_3x3_board")
+        input_curr_digit = Input(shape=(1,), name="current_digit")
+        input_next_digit = Input(shape=(1,), name="next_digit")
+
+        board = Reshape((3, 3, 1))(input_board)
+        prev = board
+
+        for _ in range(self.params.conv_layers):
+            prev = Conv2D(
+                filters=self.params.conv_filters,
+                kernel_size=(2, 2),
+                padding="same",
+                activation="relu",
+            )(prev)
+
+        flat = Flatten()(prev)
+        # TODO(digit-party-5x5): try broadcasting current/next digits as extra
+        # 2D planes before the conv stack instead of appending them here as
+        # scalars. That would let spatial filters condition on digit context
+        # earlier in the network.
+        prev = Concatenate()([flat, input_curr_digit, input_next_digit])
+
+        for _ in range(self.params.dense_layers):
+            prev = Dense(self.params.dense_units, activation="relu")(prev)
+
+        q_values = Dense(9, activation=self.params.output_activation, name="q")(prev)
+
+        self.model = Model(
+            inputs=[input_board, input_curr_digit, input_next_digit], outputs=q_values
+        )
+        self.model.compile(
+            loss="mean_squared_error",
+            optimizer=Adam(learning_rate=self.params.learning_rate),
+        )
+
+
+def train_3x3_dqn(episodes: int | None = None) -> None:
+    cur_dir = pathlib.Path(__file__).parent.resolve()
+    model_folder = f"{cur_dir}/{MODELS_FOLDER}/"
+    nn = DigitParty3x3DeepQNN(params=DQN_3X3_NN_PARAMS, model_folder=model_folder)
+    target_nn = DigitParty3x3DeepQNN(
+        params=DQN_3X3_NN_PARAMS, model_folder=model_folder
+    )
+    train_digit_party_dqn(
+        n=3,
+        nn=nn,
+        target_nn=target_nn,
+        params=DQN_3X3_PARAMS,
+        training_artifacts_folder=f"{cur_dir}/{ARTIFACTS_FOLDER}/",
+        eval_games=TRAINING_EVAL_GAMES,
+        final_eval_games=FINAL_EVAL_GAMES,
+        episodes_override=episodes,
+    )
+
+
+def eval_3x3_best(games: int = 1000) -> None:
+    cur_dir = pathlib.Path(__file__).parent.resolve()
+    model_folder = f"{cur_dir}/{MODELS_FOLDER}"
+    nn = DigitParty3x3DeepQNN(params=DQN_3X3_NN_PARAMS, model_folder=f"{model_folder}/")
+    eval_best_digit_party_dqn(
+        n=3,
+        nn=nn,
+        best_model_file=f"{model_folder}/best_model.weights.h5",
+        games=games,
+    )
+
+
+def deep_q_3x3_trained_game() -> None:
+    train_3x3_dqn()
+
+
+def best_model_game(games: int = 1000) -> None:
+    eval_3x3_best(games=games)

--- a/src/games/digit_party/train_q_deep_5x5.py
+++ b/src/games/digit_party/train_q_deep_5x5.py
@@ -1,0 +1,145 @@
+import pathlib
+from typing import NamedTuple
+
+from keras.layers import (  # type: ignore
+    Concatenate,
+    Conv2D,
+    Dense,
+    Flatten,
+    Input,
+    Reshape,
+)
+from keras.models import Model  # type: ignore
+from keras.optimizers import Adam  # type: ignore
+
+from games.digit_party.deep_q_common import (
+    BaseDigitPartyDeepQNN,
+    eval_best_digit_party_dqn,
+    train_digit_party_dqn,
+)
+from learners.deep_q import DeepQParameters
+
+
+class DigitParty5x5DQNParams(NamedTuple):
+    conv_layers: int
+    conv_filters: int
+    dense_layers: int
+    dense_units: int
+    learning_rate: float
+    batch_size: int
+    epochs: int
+    output_activation: str
+    normalize_scale: float
+
+
+DQN_5X5_NN_PARAMS = DigitParty5x5DQNParams(
+    conv_layers=8,
+    conv_filters=24,
+    dense_layers=1,
+    dense_units=512,
+    learning_rate=0.00075,
+    batch_size=128,
+    epochs=1,
+    output_activation="linear",
+    normalize_scale=9.0,
+)
+
+DQN_5X5_PARAMS = DeepQParameters(
+    alpha=0.1,
+    gamma=0.95,
+    min_epsilon=0.05,
+    max_epsilon=1,
+    epsilon_decay=0.00002,
+    valid_action_reward=0.01,
+    memory_size=500_000,
+    min_replay_size=25_000,
+    minibatch_size=128,
+    steps_to_train_longterm=4,
+    steps_to_train_shortterm=0,
+    steps_per_target_update=500,
+    training_episodes=500_000,
+    episodes_per_model_save=10_000,
+    episodes_per_memory_save=10_000,
+    episodes_per_stats_print=1_000,
+    episodes_per_evaluation=5_000,
+    state_tracker_size_bits=67_108_864,
+    state_tracker_num_hashes=7,
+)
+
+MODELS_FOLDER = "deepq_5x5_models"
+ARTIFACTS_FOLDER = "deepq_5x5_artifacts"
+TRAINING_EVAL_GAMES = 250
+FINAL_EVAL_GAMES = 1000
+
+
+class DigitParty5x5DeepQNN(BaseDigitPartyDeepQNN):
+    def __init__(self, params: DigitParty5x5DQNParams, model_folder: str) -> None:
+        super().__init__(
+            model_folder=model_folder,
+            batch_size=params.batch_size,
+            epochs=params.epochs,
+            normalize_scale=params.normalize_scale,
+        )
+        self.params = params
+
+        input_board = Input(shape=(5, 5), name="dp_5x5_board")
+        input_curr_digit = Input(shape=(1,), name="current_digit")
+        input_next_digit = Input(shape=(1,), name="next_digit")
+
+        board = Reshape((5, 5, 1))(input_board)
+        prev = board
+
+        for _ in range(self.params.conv_layers):
+            prev = Conv2D(
+                filters=self.params.conv_filters,
+                kernel_size=(3, 3),
+                padding="same",
+                activation="relu",
+            )(prev)
+
+        flat = Flatten()(prev)
+        prev = Concatenate()([flat, input_curr_digit, input_next_digit])
+
+        for _ in range(self.params.dense_layers):
+            prev = Dense(self.params.dense_units, activation="relu")(prev)
+
+        q_values = Dense(25, activation=self.params.output_activation, name="q")(prev)
+
+        self.model = Model(
+            inputs=[input_board, input_curr_digit, input_next_digit], outputs=q_values
+        )
+        self.model.compile(
+            loss="mean_squared_error",
+            optimizer=Adam(learning_rate=self.params.learning_rate),
+        )
+
+
+def train_5x5_dqn(episodes: int | None = None) -> None:
+    cur_dir = pathlib.Path(__file__).parent.resolve()
+    model_folder = f"{cur_dir}/{MODELS_FOLDER}/"
+    nn = DigitParty5x5DeepQNN(params=DQN_5X5_NN_PARAMS, model_folder=model_folder)
+    target_nn = DigitParty5x5DeepQNN(
+        params=DQN_5X5_NN_PARAMS, model_folder=model_folder
+    )
+    train_digit_party_dqn(
+        n=5,
+        nn=nn,
+        target_nn=target_nn,
+        params=DQN_5X5_PARAMS,
+        training_artifacts_folder=f"{cur_dir}/{ARTIFACTS_FOLDER}/",
+        eval_games=TRAINING_EVAL_GAMES,
+        final_eval_games=FINAL_EVAL_GAMES,
+        episodes_override=episodes,
+    )
+
+
+def eval_5x5_best(games: int = 1000) -> None:
+    cur_dir = pathlib.Path(__file__).parent.resolve()
+    model_folder = f"{cur_dir}/{MODELS_FOLDER}"
+    nn = DigitParty5x5DeepQNN(params=DQN_5X5_NN_PARAMS, model_folder=f"{model_folder}/")
+    eval_best_digit_party_dqn(
+        n=5,
+        nn=nn,
+        best_model_file=f"{model_folder}/best_model.weights.h5",
+        games=games,
+    )

--- a/test/games/test_digit_party_deep_q.py
+++ b/test/games/test_digit_party_deep_q.py
@@ -1,0 +1,95 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+
+from games.digit_party.game import DigitPartyState
+from games.game import P1
+from learners.deep_q import DQNOutput
+
+
+def test_digit_party_deep_q_defaults_to_3x3_best_eval() -> None:
+    from games.digit_party import train_q_deep
+
+    with (
+        patch.object(train_q_deep, "eval_3x3_best") as eval_3x3_best,
+        patch.object(train_q_deep, "train_3x3_dqn") as train_3x3_dqn,
+        patch.object(train_q_deep, "eval_5x5_best") as eval_5x5_best,
+        patch.object(train_q_deep, "train_5x5_dqn") as train_5x5_dqn,
+    ):
+        train_q_deep.main(SimpleNamespace(size="3", mode="eval-best", games=1000))
+
+    eval_3x3_best.assert_called_once_with(games=1000)
+    train_3x3_dqn.assert_not_called()
+    eval_5x5_best.assert_not_called()
+    train_5x5_dqn.assert_not_called()
+
+
+def test_digit_party_deep_q_dispatches_5x5_train_override() -> None:
+    from games.digit_party import train_q_deep
+
+    with (
+        patch.object(train_q_deep, "eval_3x3_best") as eval_3x3_best,
+        patch.object(train_q_deep, "train_3x3_dqn") as train_3x3_dqn,
+        patch.object(train_q_deep, "eval_5x5_best") as eval_5x5_best,
+        patch.object(train_q_deep, "train_5x5_dqn") as train_5x5_dqn,
+    ):
+        train_q_deep.main(
+            SimpleNamespace(size="5", mode="train", games=250, episodes=123)
+        )
+
+    eval_3x3_best.assert_not_called()
+    train_3x3_dqn.assert_not_called()
+    eval_5x5_best.assert_not_called()
+    train_5x5_dqn.assert_called_once_with(episodes=123)
+
+
+def test_digit_party_5x5_dqn_normalizes_inputs() -> None:
+    from games.digit_party.train_q_deep_5x5 import (
+        DQN_5X5_NN_PARAMS,
+        DigitParty5x5DeepQNN,
+    )
+
+    nn = DigitParty5x5DeepQNN(params=DQN_5X5_NN_PARAMS, model_folder="")
+    state = DigitPartyState(
+        board=np.array(
+            [
+                [0, 1, 2, 3, 4],
+                [5, 6, 7, 8, 9],
+                [9, 8, 7, 6, 5],
+                [4, 3, 2, 1, 0],
+                [1, 2, 3, 4, 5],
+            ],
+            dtype=float,
+        ),
+        player=P1,
+        next=(9, 3),
+        score=0,
+        theoretical_max=0,
+        digits=[],
+    )
+    output = DQNOutput(policy=np.zeros(25), value=0.0)
+    fit_inputs: list[np.ndarray] = []
+    predict_inputs: list[np.ndarray] = []
+
+    def fake_fit(x, y, batch_size, epochs, shuffle, verbose) -> None:
+        del y, batch_size, epochs, shuffle, verbose
+        fit_inputs.extend(x)
+
+    def fake_predict(x, verbose):
+        del verbose
+        predict_inputs.extend(x)
+        return np.zeros((1, 25))
+
+    nn.model.fit = fake_fit  # type: ignore[method-assign]
+    nn.model.predict = fake_predict  # type: ignore[method-assign]
+
+    nn.train([(state, output)])
+    nn.predict([state])
+
+    np.testing.assert_allclose(fit_inputs[0], np.asarray([state.board / 9.0]))
+    np.testing.assert_allclose(fit_inputs[1], np.asarray([1.0]))
+    np.testing.assert_allclose(fit_inputs[2], np.asarray([3.0 / 9.0]))
+    np.testing.assert_allclose(predict_inputs[0], np.asarray([state.board / 9.0]))
+    np.testing.assert_allclose(predict_inputs[1], np.asarray([1.0]))
+    np.testing.assert_allclose(predict_inputs[2], np.asarray([3.0 / 9.0]))


### PR DESCRIPTION
## Summary
- keep the Digit Party DQN harness shared while splitting 3x3 and 5x5 network definitions into separate modules
- add the first 5x5 DQN architecture and training schedule, including normalized digit inputs and separate model/artifact folders
- keep the deep-q CLI simple with size/mode dispatch while preserving the old 3x3 default behavior
- add focused tests for deep-q dispatch and 5x5 input normalization

## Testing
- `make lint`
- `make test`
- `make run ARGS="digit_party_deep_q --size 5 --mode train --episodes 1"`
